### PR TITLE
Fix CI: add .npmrc for legacy peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `legacy-peer-deps=true` to fix `npm ci` failure in GitHub Actions
- `@astrojs/tailwind@6.0.2` works correctly with Astro 6 but hasn't updated its peer dependency declaration to include `^6.0.0` yet
- `npm ci` is strict about peer deps by default; `.npmrc` instructs it to allow this

## Test plan
- [x] `npm ci` completes without errors
- [x] `npm run build` produces successful static build

🤖 Generated with [Claude Code](https://claude.com/claude-code)