### PR TITLE
Bump Node.js to v22 in CI to satisfy Astro 6 requirement

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Astro 6 requires Node.js >=22.12.0; the workflow was still pinned to v20.