### PR TITLE
Replace GA4 with Cloudflare Web Analytics + Microsoft Clarity

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,12 +27,20 @@ const {
       href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,300..900;1,14..32,300..900&display=swap"
       rel="stylesheet"
     />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TPXVMVQNG5"></script>
+    <!-- Cloudflare Web Analytics -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "4f400efd93b344c7bd0ec3795a013575"}'
+    ></script>
+
+    <!-- Microsoft Clarity -->
     <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-      gtag('config', 'G-TPXVMVQNG5');
+      (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window,document,"clarity","script","w3y51z0w6z");
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Removes Google Analytics 4 (GA4) from the site layout
- Adds **Cloudflare Web Analytics** for cookieless visitor stats — no GDPR consent banner required
- Adds **Microsoft Clarity** for heatmaps and session recordings

## Test plan
- [ ] Verify build passes in CI
- [ ] After merge and deployment, click "Verify site" in Cloudflare Web Analytics dashboard
- [ ] After merge and deployment, click "Verify installation" in Microsoft Clarity dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)